### PR TITLE
Add CLI Tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv/
 __pycache__/
 *.pyc
+# Python packaging
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ scrapper components-of "Acoustic Guitar"
 - ✅ **Scraper** — fetches and parses the wiki’s junk items table into SQLite.
 - ✅ **Schema** — normalized tables for clean joins and queries.
 - ✅ **Basic queries** — `.sql` files in `sql/` for common lookups.
+- ✅ **CLI tool** — using Typer for commands.
 - 🚧 **Intermediate/Advanced queries** - todo - LEFT JOIN? No problem, once we refresh some basics let's get our hands dirty with:
   - Left Joins
   - Self Joins
@@ -61,7 +62,78 @@ scrapper components-of "Acoustic Guitar"
   - Common Table Expressions
   - Co-occurence analysis
   - Ranking & window function
-- 🚧 **CLI tool** — in progress (using Typer for commands).
+
+---
+
+### CLI Setup & Usage
+
+The Fallout 76 scrap lookup tool now includes a command-line interface powered by [Typer](https://typer.tiangolo.com/).
+
+#### Install locally
+
+1. Clone the repository
+
+```bash
+git clone https://github.com/<your-username>/fallout76-scrapper.git
+cd fallout76-scrapper
+```
+
+2. Create virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # macOS/Linux
+.venv\Scripts\activate     # Windows
+```
+
+3. Install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+#### First-time setup
+
+Run the `init` function to begin, this will populate your local database:
+
+```bash
+f76 init
+```
+
+By default, the database will be stored at:
+
+- `data/fallout.sqlite` (if running from repo)
+- `~/.local/share/f76/fallout.sqlite` (if installed globally)
+
+#### Commands
+
+Input for each command is case insensitive.
+
+1. Show components from an item
+
+```bash
+f76 components-of "Acoustic Guitar"
+```
+
+Example output:
+| Component | Qty |
+|-----------|-----|
+| Wood | 4 |
+| Steel | 2 |
+
+2. Show items for a component
+
+```bash
+f76 items-for "cloth"
+```
+
+Lists items sorted by the amount of the component they yield.
+
+Example output:
+| Item | Qty |
+|-----------|-----|
+| Cigar Box | 2 |
+| Bumblebear| 1 |
 
 ---
 

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -1,0 +1,98 @@
+import os, pathlib, sqlite3, typer
+from rich.console import Console
+from rich.table import Table
+from .scripts.scrape_single_page import main as scraper_main
+
+app = typer.Typer(help="Fallout 76 scrap lookup")
+console = Console()
+
+def default_data_dir() -> pathlib.Path:
+    base = pathlib.Path.home() / ".local" / "share" / "f76"  # fine on mac/Linux
+    # on Windows can use: Path(os.environ.get("APPDATA", "~")) / "f76"
+    return base
+
+def resolve_db_path(db_opt: str | None = None) -> pathlib.Path:
+    # CLI flag
+    if db_opt:
+        return pathlib.Path(db_opt)
+
+    # env var
+    env = os.environ.get("F76_DB")
+    if env:
+        return pathlib.Path(env)
+
+    # Repo dev path (works when running in the repo)
+    repo_db = pathlib.Path(__file__).resolve().parents[1] / "data" / "fallout.sqlite"
+    if repo_db.exists():
+        return repo_db
+
+    # user data dir fallback
+    return default_data_dir() / "fallout.sqlite"
+
+def get_conn(db_path: pathlib.Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys=ON;")
+    return conn
+
+@app.command("components-of")
+def components_of(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Look up what components a Junk Item will scrap into (e.g., "Giddyup Buttercup")
+    """
+    db_path = resolve_db_path(db)
+    q = """
+    SELECT c.name, s.quantity
+    FROM item i
+    JOIN item_scraps s ON s.item_id = i.id
+    JOIN component   c ON c.id = s.component_id
+    WHERE i.name = ? COLLATE NOCASE
+    ORDER BY c.name;
+    """
+    with get_conn(db_path) as cx:
+        rows = cx.execute(q, (item,)).fetchall()
+    if not rows:
+        console.print(f"[bold]No scraps found for:[/bold] {item} (DB: {db_path})")
+        raise typer.Exit(1)
+    t = Table(title=f'"{item}" scraps for:')
+    t.add_column("Component"); t.add_column("Qty", justify="right")
+    for comp, qty in rows:
+        t.add_row(comp, str(qty))
+    console.print(t)
+
+@app.command("items-for")
+def items_for(component: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Look up what Junk Items yield the most of a given component (e.g., "Lead")
+    """
+    db_path = resolve_db_path(db)
+    q = """
+    SELECT i.name, s.quantity
+    FROM component c
+    JOIN item_scraps s ON s.component_id = c.id
+    JOIN item        i ON i.id = s.item_id
+    WHERE c.name = ? COLLATE NOCASE
+    ORDER BY s.quantity DESC, i.name;
+    """
+    with get_conn(db_path) as cx:
+        rows = cx.execute(q, (component,)).fetchall()
+    if not rows:
+        console.print(f"[bold]No items found for component:[/bold] {component} (DB: {db_path})")
+        raise typer.Exit(1)
+    t = Table(title=f'Items that yield "{component}"')
+    t.add_column("Item"); t.add_column("Qty", justify="right")
+    for item_name, qty in rows:
+        t.add_row(item_name, str(qty))
+    console.print(t)
+
+@app.command("init")
+def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Create/populate the database by running the scraper once.
+    """
+    db_path = resolve_db_path(db)
+    # Pass the target path via env var 
+    os.environ["F76_DB_TARGET"] = str(db_path)  
+    console.print(f"Initializing DB at: {db_path}")
+    scraper_main()
+    console.print("[green]Done.[/green]")

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -1,7 +1,10 @@
 import os, pathlib, sqlite3, typer
 from rich.console import Console
 from rich.table import Table
-from .scripts.scrape_single_page import main as scraper_main
+from .scripts.scrape.junk_items_table import main as scrape_junk_items
+
+# TODO: break this file up as commands grow 
+# CLI directory? With Utils?
 
 app = typer.Typer(help="Fallout 76 scrap lookup")
 console = Console()
@@ -94,5 +97,5 @@ def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     # Pass the target path via env var 
     os.environ["F76_DB_TARGET"] = str(db_path)  
     console.print(f"Initializing DB at: {db_path}")
-    scraper_main()
+    scrape_junk_items()
     console.print("[green]Done.[/green]")

--- a/f76/scripts/db_utils.py
+++ b/f76/scripts/db_utils.py
@@ -6,7 +6,7 @@ import sqlite3, pathlib
 # `/ "sql" / "schema.sql"` - append path to the schema file
 # In short: Computing & storing the absolute path to the schema
 # Docs: https://docs.python.org/3/library/pathlib.html
-SCHEMA = pathlib.Path(__file__).resolve().parents[1] / "sql" / "schema.sql"
+SCHEMA = pathlib.Path(__file__).resolve().parents[2] / "sql" / "schema.sql"
 
 def ensure_schema(conn: sqlite3.Connection):
     """

--- a/f76/scripts/db_utils.py
+++ b/f76/scripts/db_utils.py
@@ -1,0 +1,91 @@
+import sqlite3, pathlib
+
+# Path to the SQL schema def. file
+# `pathlib.Path(__file__)` - current file location
+# `.resolve().parents[1]` - go up 2 levels (current -> scripts/ -> project root)
+# `/ "sql" / "schema.sql"` - append path to the schema file
+# In short: Computing & storing the absolute path to the schema
+# Docs: https://docs.python.org/3/library/pathlib.html
+SCHEMA = pathlib.Path(__file__).resolve().parents[1] / "sql" / "schema.sql"
+
+def ensure_schema(conn: sqlite3.Connection):
+    """
+    Ensure that the databse has the correct schema.
+    - Enables foreign key support (disabled by default in SQLite)
+    - Executes the schema.sql to create tables if they don't exist
+
+    SQLite Pragma docs: https://www.sqlite.org/pragma.html
+    """
+    conn.execute("PRAGMA foreign_keys=ON;")
+    with open(SCHEMA, "r", encoding="utf-8") as f:
+        conn.executescript(f.read())
+
+def upsert_item(cur, name: str, url: str | None) -> int:
+    """
+    Insert or Update an item by name
+    - It an item with the given name exists, return the ID
+    - If an item exists but does not have a record URL record, update it.
+    - Or insert a new row and return the ID
+    """
+    # Look up if already exists by name - parameterized query
+    # fetchone() returns a single row or `None`
+    row = cur.execute("SELECT id FROM item WHERE name = ?", (name,)).fetchone()
+    if row:
+        if url:
+            # COALESCE returns the first non-NULL argument 
+            # Only update if `url` column is currently NULL.
+            # Docs: https://sqlite.org/lang_corefunc.html#coalesce
+            cur.execute("UPDATE item SET url = COALESCE(url, ?) WHERE id = ?", (url, row[0]))
+        return row[0]
+    cur.execute("INSERT INTO item(name, url) VALUES (?,?)", (name, url))
+    return cur.lastrowid
+
+def upsert_component(cur, name: str) -> int:
+    """
+    Insert a new component if it doesn't already exist
+    Returns the value of the component ID column either way
+    """
+    row = cur.execute("SELECT id FROM component WHERE name = ?", (name,)).fetchone()
+    if row: return row[0]
+    cur.execute("INSERT INTO component(name) VALUES (?)", (name,))
+    return cur.lastrowid
+
+def set_item_scrap(cur, item_id: int, component_id: int, qty: int):
+    """
+    Set the scrap quantity for a given `item` -> `component` mapping
+    - Uses SQLite's UPSERT capability, which we're implementing through:
+    `INSERT .... ON CONFLICT .... DO UPDATE` syntax
+
+    Flow:
+    - `INSERT INTO item_scraps(item_id, component_id, quantity)` 
+      - try to add a new row to item_scraps 
+      recording a junk item and component quantity 
+    - `ON CONFLICT(item_id, component_id)` 
+      - There's been a conflict because of a UNIQUE or PRIMARY KEY conflict
+      - i.e. if you find a record for this item and component 
+      mapping already exists
+    - `DO UPDATE SET quantity = excluded.quantity`
+      - Set the quantity to most current data
+      - 🗒️ Note on `excluded` & `UPSERT` below
+    """
+    
+    cur.execute("""
+        INSERT INTO item_scraps(item_id, component_id, quantity)
+        VALUES (?,?,?)
+        ON CONFLICT(item_id, component_id) 
+        DO UPDATE SET quantity = excluded.quantity
+    """, (item_id, component_id, qty))
+
+"""
+SQLite Fundamentals this module uses
+
+- 🆙 `UPSERT`: 
+  - Docs: https://sqlite.org/lang_upsert.html
+  - "An UPSERT is an ordinary INSERT statement that is followed 
+  by one or more ON CONFLICT clauses" 
+  - `excluded` - a special table alias automatically available 
+  inside the `DO UPDATE` clause of an `ON CONFLICT`
+    - When we try to upsert a row and we find a conflict SQLite does 2 things:
+    1. Keeps the existing row in the real table unchanged for now
+    2. Makes the row we *tried* to insert available in a special table called `excluded`
+"""

--- a/f76/scripts/parsing_utils.py
+++ b/f76/scripts/parsing_utils.py
@@ -1,0 +1,72 @@
+import re
+from bs4 import Tag, NavigableString
+
+QTY_AFTER_LINK = re.compile(r"\b(?:x|×)\s*(\d+)\b", re.I)
+FOOTNOTE_RE = re.compile(r"\[\d+\]")
+
+def clean_text(s: str) -> str:
+    s = FOOTNOTE_RE.sub("", s or "")
+    return " ".join(s.replace("\xa0", " ").split())
+
+# Class name on the Junk Items table - also belongs to several other tables
+TARGET = {"va-table", "va-table-center", "va-table-full"}
+
+
+# Tag - bs4 type - has things like tag.name, tag.attrs, etc 
+def has_all_classes(tag: Tag) -> bool:
+    return (
+        tag.name == "table"
+        # issubset - return `True` if all elements of TARGET are present in passed set
+        # set - converts the list into Python `set` - no duplicate values
+        # tag.get(attr_name, default) - return the attr value if exists - otherwise default 
+        and TARGET.issubset(set(tag.get("class", [])))
+    )
+
+
+def parse_components_cell(cell: Tag):
+    """
+    Parse a components <td> that looks like:
+    <a>Steel</a><br><a>Lead</a>
+    or:
+    <a>Steel</a> x2<br><a>Lead</a> x3
+    Returns: list[(qty:int, name:str)]
+    """
+    groups, current = [], []
+    for child in cell.children:
+        if getattr(child, "name", None) == "br":
+            if current:
+                groups.append(current); current = []
+            continue
+        current.append(child)
+    if current: # last group
+        groups.append(current)
+
+    results = []
+    for nodes in groups:
+        # Find the component link
+        link = next((n for n in nodes if isinstance(n, Tag) and n.name == "a"), None)
+        if not link:
+            # fallback to plain text
+            text = " ".join(str(n).strip() for n in nodes if isinstance(n, (NavigableString,)))
+            text = re.sub(r"\s+", " ", text).strip(" .;")
+            if text:
+                # try "Name x2" pattern
+                m = QTY_AFTER_LINK.search(text)
+                qty = int(m.group(1)) if m else 1
+                name = QTY_AFTER_LINK.sub("", text).strip()
+                if name:
+                    results.append((qty, name))
+            continue
+        
+        name = link.get_text(strip=True)
+        # Look for qty in the text immediately after the link (e.g., " x2")
+        qty = 1
+        sib = link.next_sibling
+        if isinstance(sib, NavigableString):
+            m = QTY_AFTER_LINK.search(str(sib))
+            if m:
+                qty = int(m.group(1))
+
+        if name:
+            results.append((qty, name))
+    return results

--- a/f76/scripts/scrape/junk_items_table.py
+++ b/f76/scripts/scrape/junk_items_table.py
@@ -2,19 +2,14 @@ import os, sqlite3, pathlib, requests
 from bs4 import BeautifulSoup
 # Note: when Python runs a file, it will compile it into bytecode (.pyc files)
 # This makes it faster to load these modules next time. Compiled files live in `__pycache__`
-from .parsing_utils import clean_text, has_all_classes, parse_components_cell
-from .db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
+from ..parsing_utils import clean_text, has_all_classes, parse_components_cell
+from ..db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
 
 URL = "https://fallout.fandom.com/wiki/Fallout_76_junk_items"
 HEADERS = {"User-Agent": "ash-sql-learning/0.1 (personal, low-traffic)"}
 
-# DB = pathlib.Path(__file__).resolve().parents[1] / "data" / "fallout.sqlite"
-# DB = pathlib.Path(os.environ.get("F76_DB_TARGET", "")) or pathlib.Path(__file__).resolve().parents[2] / "data" / "fallout.sqlite"
-
 def default_repo_db() -> pathlib.Path:
-    # this file: f76/scripts/scrape_single_page.py
-    # project root = parents[2]
-    return pathlib.Path(__file__).resolve().parents[2] / "data" / "fallout.sqlite"
+    return pathlib.Path(__file__).resolve().parents[3] / "data" / "fallout.sqlite"
 
 def main(db_path: str | pathlib.Path | None = None):
       # 1) CLI arg > 2) env var > 3) repo default

--- a/f76/scripts/scrape_single_page.py
+++ b/f76/scripts/scrape_single_page.py
@@ -2,15 +2,26 @@ import os, sqlite3, pathlib, requests
 from bs4 import BeautifulSoup
 # Note: when Python runs a file, it will compile it into bytecode (.pyc files)
 # This makes it faster to load these modules next time. Compiled files live in `__pycache__`
-from parsing_utils import clean_text, has_all_classes, parse_components_cell
-from db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
+from .parsing_utils import clean_text, has_all_classes, parse_components_cell
+from .db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
 
 URL = "https://fallout.fandom.com/wiki/Fallout_76_junk_items"
 HEADERS = {"User-Agent": "ash-sql-learning/0.1 (personal, low-traffic)"}
 
-DB = pathlib.Path(__file__).resolve().parents[1] / "data" / "fallout.sqlite"
+# DB = pathlib.Path(__file__).resolve().parents[1] / "data" / "fallout.sqlite"
+# DB = pathlib.Path(os.environ.get("F76_DB_TARGET", "")) or pathlib.Path(__file__).resolve().parents[2] / "data" / "fallout.sqlite"
 
-def main():
+def default_repo_db() -> pathlib.Path:
+    # this file: f76/scripts/scrape_single_page.py
+    # project root = parents[2]
+    return pathlib.Path(__file__).resolve().parents[2] / "data" / "fallout.sqlite"
+
+def main(db_path: str | pathlib.Path | None = None):
+      # 1) CLI arg > 2) env var > 3) repo default
+    DB = pathlib.Path(db_path) if db_path else pathlib.Path(
+        os.environ.get("F76_DB_TARGET") or default_repo_db()
+    )
+    
     DB.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(DB) as conn:
         ensure_schema(conn)
@@ -18,7 +29,7 @@ def main():
         html = requests.get(URL, headers=HEADERS, timeout=30)
         html.raise_for_status()
         soup = BeautifulSoup(html.text, "html.parser")
-        print("soup:", soup)
+        # print("soup:", soup)
         # ---- Only the "Junk items" table ----
         anchor = soup.select_one("#Junk_items")  # <span id="Junk_items">
         if not anchor:
@@ -66,7 +77,7 @@ def main():
                     url = "https://fallout.fandom.com" + url
 
             comps = parse_components_cell(comp_cell)
-            print("Comps", comps)
+            # print("Comps", comps)
             if not comps:
                 continue
 

--- a/f76/sql/schema.sql
+++ b/f76/sql/schema.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS item (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  url  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS component (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS item_scraps (
+  item_id INTEGER NOT NULL REFERENCES item(id) ON DELETE CASCADE,
+  component_id INTEGER NOT NULL REFERENCES component(id) ON DELETE RESTRICT,
+  quantity INTEGER NOT NULL,
+  PRIMARY KEY (item_id, component_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_name ON item(name);
+CREATE INDEX IF NOT EXISTS idx_component_name ON component(name);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "f76"
+version = "0.1.0"
+description = "Fallout 76 scrap lookup CLI"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = ["typer[all]", "rich"]
+
+[project.scripts]
+f76 = "f76.cli:app"
+
+[tool.setuptools.packages.find]
+include = ["f76*"]
+exclude = ["data*", "sql*", "scripts*", "tests*"]


### PR DESCRIPTION
## Summary 

Add CLI tooling with [Typer](https://typer.tiangolo.com/) for scrap lookup. 

## Changes 

- Adds `pyproject.toml` 
  - [PEP 621](https://peps.python.org/pep-0621/) compliant configuration
  - Defines the project name, deps, and CLI entry point
  - Restricted package discovery to avoid including raw data/test directories (but I'd like to set up a small SQL playground here perhaps, to build and discuss queries?)
- `__init__.py` - treats f76 as package 

### CLI

- Introduces CLI tooling with Typer 
  - Adds commands:
    - `init` - Runs the `junk_items_table` scrape script - navigating to Nukapedia, grabbing the Junk Items table, and populating the DB with the items and their components 
    - `items-for` - `f76 items-for "lead"` - given a component (scrapping material) name, list all the junk items that scrap into it (sorted by yield)
    - `components-of` - `f76 components-of "giddyup buttercup"` - given a junk item name, list the components and quantity of components it will break down into


<img width="1001" height="193" alt="image" src="https://github.com/user-attachments/assets/f24ffafa-25e2-4c3a-9812-ffa1015a6a1a" />

<img width="810" height="668" alt="image" src="https://github.com/user-attachments/assets/6b07ea2a-0c3c-49d4-94a7-1895398c3bff" />

### Future Work 

- Allow SQL commands in CLI input for adhoc database searching 
- Add tables for game [Regions and Locations](https://fallout.fandom.com/wiki/Fallout_76_locations#Regions) - so we can start building the foundation for a command that can tell users where to go to get desired junk items/scrap. 