### PR TITLE
Add Enemy Categories & Groups

### DIFF
--- a/f76/cli.py
+++ b/f76/cli.py
@@ -199,6 +199,7 @@ def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
         t.add_row(loc_name, str(qty) if qty is not None else "-", desc)
     console.print(t)
         
+# TODO: @app.command(TBD) - command for enemy information
 
 @app.command("init")
 def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -4,6 +4,7 @@ from rich.table import Table
 from .scripts.scrape.junk_items_table import main as scrape_junk_items
 from .scripts.scrape.regions_and_locations import main as scrape_regions_and_locations
 from .scripts.scrape.junk_locations import scrape_item_locations_by_name
+from .scripts.scrape.enemies import main as scrape_enemy_categories
 from .scripts.db_utils import fetch_all
 from rich import box
 
@@ -200,6 +201,21 @@ def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
     console.print(t)
         
 # TODO: @app.command(TBD) - command for enemy information
+@app.command("enemy")
+def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Create/populate the database by running the scraper once.
+    """
+    db_path = resolve_db_path(db)
+    # Pass the target path via env var 
+    os.environ["F76_DB_TARGET"] = str(db_path)
+    scrape_enemy_categories(db_path)
+    # console.print(f"Initializing DB at: {db_path}")
+    # console.print(f"Preparing to initialize Scrap & Junk Items")
+    # scrape_junk_items(db_path)
+    # console.print(f"Preparing to initialize Regions & Locations")
+    # scrape_regions_and_locations(db_path)
+    console.print("[green]Done.[/green]")
 
 @app.command("init")
 def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -170,6 +170,9 @@ def locations_in(db: str | None = typer.Option(None, help="Path to fallout.sqlit
 
 @app.command("where")
 def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    List locations where a junk item can be found (example `f76 where soap`)
+    """
     db_path = resolve_db_path(db)
     # lazy pop: scrape if we have no rows
     q_check = "SELECT COUNT(*) FROM item_locations il JOIN item i ON i.id = il.item_id WHERE i.name = ? COLLATE NOCASE"

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -200,22 +200,8 @@ def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
         t.add_row(loc_name, str(qty) if qty is not None else "-", desc)
     console.print(t)
         
-# TODO: @app.command(TBD) - command for enemy information
-@app.command("enemy")
-def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
-    """
-    Create/populate the database by running the scraper once.
-    """
-    db_path = resolve_db_path(db)
-    # Pass the target path via env var 
-    os.environ["F76_DB_TARGET"] = str(db_path)
-    scrape_enemy_categories(db_path)
-    # console.print(f"Initializing DB at: {db_path}")
-    # console.print(f"Preparing to initialize Scrap & Junk Items")
-    # scrape_junk_items(db_path)
-    # console.print(f"Preparing to initialize Regions & Locations")
-    # scrape_regions_and_locations(db_path)
-    console.print("[green]Done.[/green]")
+# TODO: 
+# @app.command("enemy")
 
 @app.command("init")
 def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
@@ -226,8 +212,13 @@ def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     # Pass the target path via env var 
     os.environ["F76_DB_TARGET"] = str(db_path)
     console.print(f"Initializing DB at: {db_path}")
+    console.print("\n")
     console.print(f"Preparing to initialize Scrap & Junk Items")
     scrape_junk_items(db_path)
+    console.print("\n")
     console.print(f"Preparing to initialize Regions & Locations")
     scrape_regions_and_locations(db_path)
+    console.print("\n")
+    console.print(f"Preparing to initialize Enemy data")
+    scrape_enemy_categories(db_path)
     console.print("[green]Done.[/green]")

--- a/f76/scripts/db_utils.py
+++ b/f76/scripts/db_utils.py
@@ -56,6 +56,30 @@ def upsert_component(cur, name: str) -> int:
     cur.execute("INSERT INTO component(name) VALUES (?)", (name,))
     return cur.lastrowid
 
+def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]]):
+    """
+    
+    """
+    # Lookup category ID
+    row = cur.execute(
+        "SELECT id FROM enemy_category WHERE name = ?",
+        (category,),
+    ).fetchone()
+    if not row:
+        raise RuntimeError(f"Category {category} could not be found in DB.")
+    category_id = row[0]
+
+    for name, url in groups:
+        cur.execute(
+            """
+            INSERT INTO enemy_group (category_id, name, url)
+            VALUES(?,?,?)
+            ON CONFLICT(category_id, name) DO NOTHING
+            """,
+            (category_id, name, url)
+        )
+    print(f"Loaded {len(groups)} enemy groups for {category}")
+
 def set_item_scrap(cur, item_id: int, component_id: int, qty: int):
     """
     Set the scrap quantity for a given `item` -> `component` mapping

--- a/f76/scripts/db_utils.py
+++ b/f76/scripts/db_utils.py
@@ -58,7 +58,7 @@ def upsert_component(cur, name: str) -> int:
 
 def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]]):
     """
-    
+    Insert or ignore list of enemy groups for given category.
     """
     # Lookup category ID
     row = cur.execute(

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -2,7 +2,7 @@ import pathlib
 from bs4 import BeautifulSoup
 
 from .infra import db_conn, fetch_soup
-from ..parsing_utils import clean_text, has_all_classes, parse_components_cell
+from ..parsing_utils import clean_text
 from ..db_utils import ensure_schema, upsert_enemy_groups
 
 URL = "https://fallout.fandom.com/wiki/Fallout_76_creatures"

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -5,75 +5,120 @@ from .infra import db_conn, fetch_soup
 from ..parsing_utils import clean_text, has_all_classes, parse_components_cell
 from ..db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
 
-URL = "https://fallout.fandom.com/wiki/Fallout_76_junk_items"
+URL = "https://fallout.fandom.com/wiki/Fallout_76_creatures"
+
+ENEMY_CATEGORIES = ["Humans", "Creatures", "Robots"]
 
 def main(db_path: str | pathlib.Path | None = None):
     soup: BeautifulSoup = fetch_soup(URL)
 
-    # TODO: Identify landmarks
-    anchor = soup.select_one("#Junk_items")
-    if not anchor:
-        raise SystemExit("Couldn't find #Junk_items anchor")
-    
-    h3 = anchor.find_parent("h3")
-    if not h3:
-        raise RuntimeError("Could not find parent <h3> for #Junk_items")
-    
-    table = h3.find_next(has_all_classes)
-    if not table:
-        raise RuntimeError("Couldn't find the va-table/center/full table")
-    
-    header_cells = table.select("tr")[0].find_all(["th", "td"])
-    headers = [clean_text(h.get_text(" ", strip=True)).lower() for h in header_cells]
+    print("Soup 🍲: ", soup)
 
-    try:
-        name_idx = next(i for i,h in enumerate(headers) if h.startswith("name"))
-        comp_idx = next(i for i,h in enumerate(headers) if "component" in h)
-    except StopIteration:
-        raise SystemExit(f"Unexpected headers: {headers}")
+# We know there are three catgories:
+# Humans: <span class="mw-headline" id="Humans">Humans</span>
+# Creatures: <span class="mw-headline" id="Creatures">Creatures</span>
+# Robots: <span class="mw-headline" id="Robots">Robots</span> 
+# Let's just hardcode what we know so we can drill down beneath each of those.
     
-    total_items, total_links = 0, 0
+    # Make sure enemy categories present in HTML
+    for category in ENEMY_CATEGORIES:
+        anchor = soup.select_one(f"span.mw-headline#{category}")
+        if not anchor:
+            raise SystemExit(f"Couldn't find {category} anchor")
 
-    # Open DB and ensure schema
+    # We can go ahead and load these into the database
     with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
-        for row in table.select("tr")[1:]:
-            tds = row.find_all(["td", "th"])
-            if len(tds) <= max(name_idx, comp_idx):
-                continue
+        with conn:
+            cur = conn.cursor()
+            for category in ENEMY_CATEGORIES:
+                cur.execute(
+                    """
+                    INSERT INTO enemy_category (name)
+                    VALUES (?)
+                    ON CONFLICT(name) DO NOTHING
+                    """,
+                    (category,),
+                )
 
-            name_cell = tds[name_idx]
-            comp_cell = tds[comp_idx]
+    print(f"Loaded {len(ENEMY_CATEGORIES)} enemy categories.")
 
-            a = name_cell.find("a")
-            name = clean_text(a.get_text() if a else name_cell.get_text())
-            if not name:
-                continue
+# Now we can go on to pulling from categories
+# Under each of these headings we find tables
+# Humans has one bullet point (a note on legendary effect, which we'll ignore)
+# and then a complex table 
 
-            url = None
-            if a and a.has_attr("href"):
-                url = a["href"]
-                if url.startswith("/"):
-                    url = "https://fallout.fandom.com" + url
 
-            comps = parse_components_cell(comp_cell)
-            if not comps:
-                continue
+# Sometimes, in the case of Creatures, we find various subheadings:
+# <span class="mw-headline" id="Animals">Animals</span> - these are h3's
+# There is animals, Bugs and insects, cryptids, etc. 
+# Not all three of them have this...
 
-            # TODO: We're only setting components based on items and what they scrap into
-            # there are more components than this in the game, acquired only through collection
-            # For now this is more efficient for our use case, we can extend this in the future
-            with conn:
-                cur = conn.cursor()
-                # TODO: add enemy categories 
-                # item_id = upsert_item(cur, name, url)
-                # for qty, comp_name in comps:
-                #     comp_id = upsert_component(cur, comp_name)
-                #     set_item_scrap(cur, item_id, comp_id, qty)
-                #     total_links += 1
-            total_items += 1
 
-    # TODO: future:  with {total_links} enemy types, etc. - breakdown of enemies we're adding
-    print(f"Loaded {total_items} enemy categories.")
+    # OLD CODE: (left as a skeleton)
+    # TODO: Identify landmarks
+    # anchor = soup.select_one("#Junk_items")
+    # if not anchor:
+    #     raise SystemExit("Couldn't find #Junk_items anchor")
+    
+    # h3 = anchor.find_parent("h3")
+    # if not h3:
+    #     raise RuntimeError("Could not find parent <h3> for #Junk_items")
+    
+    # table = h3.find_next(has_all_classes)
+    # if not table:
+    #     raise RuntimeError("Couldn't find the va-table/center/full table")
+    
+    # header_cells = table.select("tr")[0].find_all(["th", "td"])
+    # headers = [clean_text(h.get_text(" ", strip=True)).lower() for h in header_cells]
+
+    # try:
+    #     name_idx = next(i for i,h in enumerate(headers) if h.startswith("name"))
+    #     comp_idx = next(i for i,h in enumerate(headers) if "component" in h)
+    # except StopIteration:
+    #     raise SystemExit(f"Unexpected headers: {headers}")
+    
+    # total_items, total_links = 0, 0
+
+    # # Open DB and ensure schema
+    # with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
+    #     for row in table.select("tr")[1:]:
+    #         tds = row.find_all(["td", "th"])
+    #         if len(tds) <= max(name_idx, comp_idx):
+    #             continue
+
+    #         name_cell = tds[name_idx]
+    #         comp_cell = tds[comp_idx]
+
+    #         a = name_cell.find("a")
+    #         name = clean_text(a.get_text() if a else name_cell.get_text())
+    #         if not name:
+    #             continue
+
+    #         url = None
+    #         if a and a.has_attr("href"):
+    #             url = a["href"]
+    #             if url.startswith("/"):
+    #                 url = "https://fallout.fandom.com" + url
+
+    #         comps = parse_components_cell(comp_cell)
+    #         if not comps:
+    #             continue
+
+    #         # TODO: We're only setting components based on items and what they scrap into
+    #         # there are more components than this in the game, acquired only through collection
+    #         # For now this is more efficient for our use case, we can extend this in the future
+    #         with conn:
+    #             cur = conn.cursor()
+    #             # TODO: add enemy categories 
+    #             # item_id = upsert_item(cur, name, url)
+    #             # for qty, comp_name in comps:
+    #             #     comp_id = upsert_component(cur, comp_name)
+    #             #     set_item_scrap(cur, item_id, comp_id, qty)
+    #             #     total_links += 1
+    #         total_items += 1
+
+    # # TODO: future:  with {total_links} enemy types, etc. - breakdown of enemies we're adding
+    # print(f"Loaded {total_items} enemy categories.")
 
 if __name__ == "__main__":
     main()

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -9,10 +9,45 @@ URL = "https://fallout.fandom.com/wiki/Fallout_76_creatures"
 
 ENEMY_CATEGORIES = ["Humans", "Creatures", "Robots"]
 
+def parse_humans_groups(soup: BeautifulSoup) -> list[tuple[str, str | None]]:
+    """
+    Returns...
+
+    """
+    # TODO: Broaden, single use for now
+    anchor = soup.select_one("span.mw-headline#Humans")
+    if not anchor:
+        raise RuntimeError("Couldn't find Humans anchor")
+    
+    h2 = anchor.find_parent("h2")
+    table = h2.find_next("table", class_="va-table")
+    if not table:
+        raise RuntimeError("Couldn't find table")
+    
+    groups: list[tuple[str, str | None]] = []
+    for row in table.select("tr"):
+        th = row.find("th", colspan="3")
+        if not th:
+            continue
+        # Table row has a link with the enemy group name
+        a = th.find("a")
+        if a:
+            name = clean_text(a.get_text(" ", strip=True))
+            url = a.get("href")
+            if url and url.startswith("/"):
+                url = "https://fallout.fandom.com" + url
+        else:
+            name = clean_text(th.get_text(" ", strip=True))
+            url = None
+        # Other doesn't really help us, but will have to decide how to handle these couple of enemies
+        if name and name.lower() != "other":
+            groups.append((name, url))
+    return groups
+
 def main(db_path: str | pathlib.Path | None = None):
     soup: BeautifulSoup = fetch_soup(URL)
 
-    print("Soup 🍲: ", soup)
+    #print("Soup 🍲: ", soup)
 
 # We know there are three catgories:
 # Humans: <span class="mw-headline" id="Humans">Humans</span>
@@ -39,9 +74,32 @@ def main(db_path: str | pathlib.Path | None = None):
                     """,
                     (category,),
                 )
-
     print(f"Loaded {len(ENEMY_CATEGORIES)} enemy categories.")
+    
+    human_groups = parse_humans_groups(soup)
+    # Add human enemies to the database 
+    with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
+        with conn:
+            cur = conn.cursor()
 
+            # Get enemy category id
+            category_id = cur.execute(
+                "SELECT id FROM enemy_category WHERE name = ?",
+                ("Humans",),
+            ).fetchone()[0]
+
+
+            for name, url in human_groups:
+                cur.execute(
+                    """
+                    INSERT INTO enemy_group (category_id, name, url)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(category_id, name) DO NOTHING
+                    """,
+                    (category_id, name, url),
+                )
+    print(f"Loaded {len(ENEMY_CATEGORIES)} human enemy groups.")    
+  
 # Now we can go on to pulling from categories
 # Under each of these headings we find tables
 # Humans has one bullet point (a note on legendary effect, which we'll ignore)

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -3,26 +3,29 @@ from bs4 import BeautifulSoup
 
 from .infra import db_conn, fetch_soup
 from ..parsing_utils import clean_text, has_all_classes, parse_components_cell
-from ..db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
+from ..db_utils import ensure_schema, upsert_enemy_groups
 
 URL = "https://fallout.fandom.com/wiki/Fallout_76_creatures"
 
+# We know there are 3 categories, so we'll just hardcode them
 ENEMY_CATEGORIES = ["Humans", "Creatures", "Robots"]
 
-def parse_humans_groups(soup: BeautifulSoup) -> list[tuple[str, str | None]]:
+def parse_enemy_groups(soup: BeautifulSoup, category: str) -> list[tuple[str, str | None]]:
     """
-    Returns...
+    Given a category, finds the next available table under that heading.
+    Returns a list of (group_name, url).
 
+    Excludes "Other"
     """
     # TODO: Broaden, single use for now
-    anchor = soup.select_one("span.mw-headline#Humans")
+    anchor = soup.select_one(f"span.mw-headline#{category}")
     if not anchor:
-        raise RuntimeError("Couldn't find Humans anchor")
+        raise RuntimeError(f"Couldn't find {category} anchor")
     
     h2 = anchor.find_parent("h2")
     table = h2.find_next("table", class_="va-table")
     if not table:
-        raise RuntimeError("Couldn't find table")
+        raise RuntimeError(f"Couldn't {category} find table")
     
     groups: list[tuple[str, str | None]] = []
     for row in table.select("tr"):
@@ -47,14 +50,7 @@ def parse_humans_groups(soup: BeautifulSoup) -> list[tuple[str, str | None]]:
 def main(db_path: str | pathlib.Path | None = None):
     soup: BeautifulSoup = fetch_soup(URL)
 
-    #print("Soup 🍲: ", soup)
-
-# We know there are three catgories:
-# Humans: <span class="mw-headline" id="Humans">Humans</span>
-# Creatures: <span class="mw-headline" id="Creatures">Creatures</span>
-# Robots: <span class="mw-headline" id="Robots">Robots</span> 
-# Let's just hardcode what we know so we can drill down beneath each of those.
-    
+    #print("Soup 🍲: ", soup)    
     # Make sure enemy categories present in HTML
     for category in ENEMY_CATEGORIES:
         anchor = soup.select_one(f"span.mw-headline#{category}")
@@ -76,107 +72,20 @@ def main(db_path: str | pathlib.Path | None = None):
                 )
     print(f"Loaded {len(ENEMY_CATEGORIES)} enemy categories.")
     
-    human_groups = parse_humans_groups(soup)
-    # Add human enemies to the database 
+    human_groups = parse_enemy_groups(soup, "Humans")
+    robot_groups = parse_enemy_groups(soup, "Robots")
+    
     with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
         with conn:
             cur = conn.cursor()
+            upsert_enemy_groups(cur, "Humans", human_groups) 
+            upsert_enemy_groups(cur, "Robots", robot_groups)
 
-            # Get enemy category id
-            category_id = cur.execute(
-                "SELECT id FROM enemy_category WHERE name = ?",
-                ("Humans",),
-            ).fetchone()[0]
-
-
-            for name, url in human_groups:
-                cur.execute(
-                    """
-                    INSERT INTO enemy_group (category_id, name, url)
-                    VALUES (?, ?, ?)
-                    ON CONFLICT(category_id, name) DO NOTHING
-                    """,
-                    (category_id, name, url),
-                )
-    print(f"Loaded {len(ENEMY_CATEGORIES)} human enemy groups.")    
-  
-# Now we can go on to pulling from categories
-# Under each of these headings we find tables
-# Humans has one bullet point (a note on legendary effect, which we'll ignore)
-# and then a complex table 
-
-
-# Sometimes, in the case of Creatures, we find various subheadings:
-# <span class="mw-headline" id="Animals">Animals</span> - these are h3's
-# There is animals, Bugs and insects, cryptids, etc. 
-# Not all three of them have this...
-
-
-    # OLD CODE: (left as a skeleton)
-    # TODO: Identify landmarks
-    # anchor = soup.select_one("#Junk_items")
-    # if not anchor:
-    #     raise SystemExit("Couldn't find #Junk_items anchor")
-    
-    # h3 = anchor.find_parent("h3")
-    # if not h3:
-    #     raise RuntimeError("Could not find parent <h3> for #Junk_items")
-    
-    # table = h3.find_next(has_all_classes)
-    # if not table:
-    #     raise RuntimeError("Couldn't find the va-table/center/full table")
-    
-    # header_cells = table.select("tr")[0].find_all(["th", "td"])
-    # headers = [clean_text(h.get_text(" ", strip=True)).lower() for h in header_cells]
-
-    # try:
-    #     name_idx = next(i for i,h in enumerate(headers) if h.startswith("name"))
-    #     comp_idx = next(i for i,h in enumerate(headers) if "component" in h)
-    # except StopIteration:
-    #     raise SystemExit(f"Unexpected headers: {headers}")
-    
-    # total_items, total_links = 0, 0
-
-    # # Open DB and ensure schema
-    # with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
-    #     for row in table.select("tr")[1:]:
-    #         tds = row.find_all(["td", "th"])
-    #         if len(tds) <= max(name_idx, comp_idx):
-    #             continue
-
-    #         name_cell = tds[name_idx]
-    #         comp_cell = tds[comp_idx]
-
-    #         a = name_cell.find("a")
-    #         name = clean_text(a.get_text() if a else name_cell.get_text())
-    #         if not name:
-    #             continue
-
-    #         url = None
-    #         if a and a.has_attr("href"):
-    #             url = a["href"]
-    #             if url.startswith("/"):
-    #                 url = "https://fallout.fandom.com" + url
-
-    #         comps = parse_components_cell(comp_cell)
-    #         if not comps:
-    #             continue
-
-    #         # TODO: We're only setting components based on items and what they scrap into
-    #         # there are more components than this in the game, acquired only through collection
-    #         # For now this is more efficient for our use case, we can extend this in the future
-    #         with conn:
-    #             cur = conn.cursor()
-    #             # TODO: add enemy categories 
-    #             # item_id = upsert_item(cur, name, url)
-    #             # for qty, comp_name in comps:
-    #             #     comp_id = upsert_component(cur, comp_name)
-    #             #     set_item_scrap(cur, item_id, comp_id, qty)
-    #             #     total_links += 1
-    #         total_items += 1
-
-    # # TODO: future:  with {total_links} enemy types, etc. - breakdown of enemies we're adding
-    # print(f"Loaded {total_items} enemy categories.")
+    # TODO: Creatures 
+    # Sometimes, in the case of Creatures, we find various subheadings:
+    # <span class="mw-headline" id="Animals">Animals</span> - these are h3's
+    # There is animals, Bugs and insects, cryptids, etc. 
+    # It's the only one structured like this
 
 if __name__ == "__main__":
     main()

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -17,7 +17,6 @@ def parse_enemy_groups(soup: BeautifulSoup, category: str) -> list[tuple[str, st
 
     Excludes "Other"
     """
-    # TODO: Broaden, single use for now
     anchor = soup.select_one(f"span.mw-headline#{category}")
     if not anchor:
         raise RuntimeError(f"Couldn't find {category} anchor")

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -1,7 +1,6 @@
 import pathlib
 from bs4 import BeautifulSoup
-# Note: when Python runs a file, it will compile it into bytecode (.pyc files)
-# This makes it faster to load these modules next time. Compiled files live in `__pycache__`
+
 from .infra import db_conn, fetch_soup
 from ..parsing_utils import clean_text, has_all_classes, parse_components_cell
 from ..db_utils import ensure_schema, upsert_component, upsert_item, set_item_scrap
@@ -11,7 +10,7 @@ URL = "https://fallout.fandom.com/wiki/Fallout_76_junk_items"
 def main(db_path: str | pathlib.Path | None = None):
     soup: BeautifulSoup = fetch_soup(URL)
 
-    # Find the "Junk Items" table 
+    # TODO: Identify landmarks
     anchor = soup.select_one("#Junk_items")
     if not anchor:
         raise SystemExit("Couldn't find #Junk_items anchor")
@@ -65,14 +64,16 @@ def main(db_path: str | pathlib.Path | None = None):
             # For now this is more efficient for our use case, we can extend this in the future
             with conn:
                 cur = conn.cursor()
-                item_id = upsert_item(cur, name, url)
-                for qty, comp_name in comps:
-                    comp_id = upsert_component(cur, comp_name)
-                    set_item_scrap(cur, item_id, comp_id, qty)
-                    total_links += 1
+                # TODO: add enemy categories 
+                # item_id = upsert_item(cur, name, url)
+                # for qty, comp_name in comps:
+                #     comp_id = upsert_component(cur, comp_name)
+                #     set_item_scrap(cur, item_id, comp_id, qty)
+                #     total_links += 1
             total_items += 1
 
-    print(f"Loaded {total_items} junk items with {total_links} component links.")
+    # TODO: future:  with {total_links} enemy types, etc. - breakdown of enemies we're adding
+    print(f"Loaded {total_items} enemy categories.")
 
 if __name__ == "__main__":
     main()

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS location (
   name TEXT NOT NULL,
   region_id INTEGER NOT NULL REFERENCES region(id) ON DELETE RESTRICT,
   url TEXT,
+  -- Unique constraint: "Can't have 2 locations with the same name in a region"
   UNIQUE(name, region_id)
 );
 
@@ -47,6 +48,15 @@ CREATE TABLE IF NOT EXISTS enemy_category (
   id INTEGER PRIMARY KEY,
   name TEXT UNIQUE NOT NULL,
   url TEXT
+);
+
+-- Next grouping down -> for Humans this would be "Blood Eagles", etc
+CREATE TABLE IF NOT EXISTS enemy_group (
+  id INTEGER PRIMARY KEY,
+  category_id INTEGER NOT NULL REFERENCES enemy_category(id),
+  name TEXT NOT NULL,
+  url TEXT,
+  UNIQUE(category_id, name)
 );
 
 -- Helpful indexes for common lookups

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -42,6 +42,13 @@ CREATE TABLE IF NOT EXISTS item_locations (
   PRIMARY KEY (item_id, location_id, description)
 );
 
+-- Broadest layer of enemies 
+CREATE TABLE IF NOT EXISTS enemy_category (
+  id INTEGER PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL,
+  url TEXT
+);
+
 -- Helpful indexes for common lookups
 -- These are performance helpers - they don't change the data, but speed up certain queries
 -- Without an index SQL will scan the whole table, row by row - e.g. "full table scan"

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -82,3 +82,5 @@ CREATE INDEX IF NOT EXISTS idx_item_locations_location ON item_locations(locatio
 CREATE INDEX IF NOT EXISTS idx_item_name ON item(name);
 -- Speeds up queries for details about items by component name
 CREATE INDEX IF NOT EXISTS idx_component_name ON component(name);
+-- Enemy groups by category
+CREATE INDEX IF NOT EXISTS idx_enemy_group_category ON enemy_group(category_id);


### PR DESCRIPTION

## Summary 

- Adds `enemies.py` to scrape https://fallout.fandom.com/wiki/Fallout_76_creatures 
- Updates `init` command to use `enemies.py`
- Adds `upsert_enemy_groups` to db helpers 

## Context 

The Fallout 76 creatures page (effectively the "enemy" page) is complex and inconsistent. To keep this change manageable, this PR focuses on the Humans and Robots categories only:

- Scrapes the first-level groups (e.g., Blood Eagles, Raiders, Protectrons, Assaultrons)
- Populates `enemy_category` and `enemy_group` tables
- Skips the Creatures category for now, since its structure differs and will be handled in a follow-up PR
- Does not yet include individual enemy types (last layer)

The work in the PR covers adding Human and Robot enemy categories and their first-level groups:

<img width="1198" height="1934" alt="image" src="https://github.com/user-attachments/assets/51136b58-df01-4763-9fe3-5c38732efeb5" />

The creatures part of this page doesn't follow the same structure, and we'll construct it in another PR for ease of understanding. 

## Testing 

1. `f76 init`
2. Should create and populate enemy_category and enemy_group tables 
3. Should add data for Humans and Robots

<img width="804" height="443" alt="image" src="https://github.com/user-attachments/assets/6d460e2f-ee61-446a-a10e-f8b1c69b0ac6" />
