### PR TITLE
Feat: Refactor CLI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,88 +109,114 @@ By default, the database will be stored at:
 
 #### Commands
 
-Input for each command is case insensitive.
+Input for each command is **case-insensitive**.
+Commands aim to follow the pattern:
 
-1. Show components from an item
-
-```bash
-f76 scrap 'Acoustic Guitar'
+```
+f76 <noun> <verb> <target>
 ```
 
-Example output:
+---
+
+### 1. Show components from a junk item
+
+```bash
+f76 junk scrap 'Acoustic Guitar'
+```
+
+Lists the components that can be obtained from scrapping a junk item.
+
+**Example output:**
+
 | Component | Qty |
-|-----------|-----|
-| Wood | 4 |
-| Steel | 2 |
+| --------- | --- |
+| Wood      | 4   |
+| Steel     | 2   |
 
-2. Show items for a component
+---
 
-```bash
-f76 sources 'cloth'
-```
-
-Lists items sorted by the amount of the component they yield.
-
-Example output:
-| Item | Qty |
-|-----------|-----|
-| Cigar Box | 2 |
-| Bumblebear| 1 |
-
-3. Get map regions
+### 2. Get known spawn locations for a junk item
 
 ```bash
-f76 regions
+f76 junk find 'Yellow Plate'
 ```
 
-Lists the regions of the Fallout 76 map
+Lists known spawn points for the given junk item, including quantities and notes.
 
-Example output:
-| Region |
-|--------------|
-| Ash Heap |
-| Cranberry Bog|
+**Example output:**
 
-4. Get a list of the locations/places in a given region
+| Location        | Qty | Description                             |
+| --------------- | --- | --------------------------------------- |
+| Overlook Cabin  | 2   | Two can be found in the Overlook Cabin  |
+| The Brown House | 10  | Ten can be found inside the Brown House |
+
+---
+
+### 3. Show junk items that yield a given component
 
 ```bash
-f76 places 'Ash Heap'
+f76 scrap sources 'Cloth'
 ```
 
-Lists the places in a region
+Lists junk items that provide the specified component when scrapped,
+sorted by the quantity yielded.
 
-Example output:
-| Locations |
-|--------------|
-| AMS testing site |
-| Abandoned mine shaft 1 |
+**Example output:**
 
-5. Get the region for a given location/place
+| Item       | Qty |
+| ---------- | --- |
+| Cigar Box  | 2   |
+| Bumblebear | 1   |
+
+---
+
+### 4. List all map regions
 
 ```bash
-f76 whereis 'Wade Airport'
+f76 region list
 ```
 
-Returns the region of the map that the given location can be found
+Displays the regions of the Fallout 76 map.
 
-Example output:
-| Region |
-|--------------|
+**Example output:**
+
+| Region        |
+| ------------- |
+| Ash Heap      |
+| Cranberry Bog |
+
+---
+
+### 5. List all locations within a given region
+
+```bash
+f76 region locations 'Ash Heap'
+```
+
+Lists the known places or locations within a specific region.
+
+**Example output:**
+
+| Location               |
+| ---------------------- |
+| AMS Testing Site       |
+| Abandoned Mine Shaft 1 |
+
+---
+
+### 6. Get the region for a given location
+
+```bash
+f76 location find 'Wade Airport'
+```
+
+Returns the region of the map where the specified location can be found.
+
+**Example output:**
+
+| Region     |
+| ---------- |
 | The Forest |
-
-6. Get location spawn points for a given junk item
-
-```bash
-f76 where 'yellow plate'
-```
-
-Returns the region of the map that the given location can be found
-
-Example output:
-| Location | Qty | Desc |
-|-----------|-----|-----------|
-| Overlook Cabin | 2 | Two can be found in the Overlook cabin
-| The Brown House | 10 | Ten can be found inside the Brown House
 
 ---
 

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -1,6 +1,7 @@
 import os, pathlib, typer
 from rich.console import Console
-from rich.table import Table
+
+from .cli_utils.cli_presentation import make_pipboy_table
 from .scripts.scrape.junk_items_table import main as scrape_junk_items
 from .scripts.scrape.regions_and_locations import main as scrape_regions_and_locations
 from .scripts.scrape.junk_locations import scrape_item_locations_by_name
@@ -9,26 +10,18 @@ from .scripts.db_utils import fetch_all
 from rich import box
 
 app = typer.Typer(help="Fallout 76 Personal Data Assistant")
+# Create sub app for registering our different items that can be acted on
+junk_app = typer.Typer(help="Explore & analyze junk items")
+scrap_app = typer.Typer(help="Explore & analyze scrap/components")
+location_app = typer.Typer(help="Explore & analyze locations")
+region_app = typer.Typer(help="Explore and analyze regions of Appalachia")
+
+app.add_typer(junk_app, name="junk")
+app.add_typer(scrap_app, name="scrap")
+app.add_typer(location_app, name="location")
+app.add_typer(region_app, name="region")
+
 console = Console()
-
-PRIMARY_GREEN = "#03e903"
-SECONDARY_GREEN = "#03AF03"
-
-def make_pipboy_table(title: str, width: int = 60) -> Table:
-    """
-    Creates table styled like a Fallout Pip-Boy.
-    Keeps consistent headers, colors, and spacing across commands.
-    """
-    return Table(
-        title=f"[{PRIMARY_GREEN}]{title}[/{PRIMARY_GREEN}]",
-        expand=False,
-        width=width,
-        show_lines=True,
-        padding=(0, 1),
-        header_style=f"bold {PRIMARY_GREEN}",
-        border_style=PRIMARY_GREEN,
-        row_styles=[PRIMARY_GREEN, SECONDARY_GREEN] # alternating row background
-    )
 
 def default_data_dir() -> pathlib.Path:
     base = pathlib.Path.home() / ".local" / "share" / "f76"  # fine on mac/Linux
@@ -53,7 +46,8 @@ def resolve_db_path(db_opt: str | None = None) -> pathlib.Path:
     # user data dir fallback
     return default_data_dir() / "fallout.sqlite"
 
-@app.command("scrap")
+# Register this action under the new junk_app
+@junk_app.command("scrap")
 def scrap(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
     Look up what components a Junk Item will scrap into (example: `f76 scrap 'Giddyup Buttercup'`)
@@ -77,98 +71,8 @@ def scrap(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
         t.add_row(comp, str(qty))
     console.print(t)
 
-@app.command("sources")
-def sources(component: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
-    """
-    Look up what Junk Items are a source of a given component (example: `f76 sources 'Lead'`)
-    """
-    q = """
-    SELECT i.name, s.quantity
-    FROM component c
-    JOIN item_scraps s ON s.component_id = c.id
-    JOIN item        i ON i.id = s.item_id
-    WHERE c.name = ? COLLATE NOCASE
-    ORDER BY s.quantity DESC, i.name;
-    """
-    db_path = resolve_db_path(db)
-    rows, _ = fetch_all(db_path, q, (component,)) 
-    if not rows:
-        console.print(f"[bold]No items found for component:[/bold] {component} (DB: {db_path})")
-        raise typer.Exit(1)
-    t = make_pipboy_table(f'Items that yield "{component}":')
-    t.add_column("Item"); t.add_column("Qty", justify="right")
-    for item_name, qty in rows:
-        t.add_row(item_name, str(qty))
-    console.print(t)
-
-@app.command("whereis")
-def region_for(location: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
-    """
-    Look up what region a location exists in. (example: `f76 whereis 'Wade Airport'`)
-    """
-    q = """
-    SELECT r.name
-    FROM region r
-    JOIN location l ON l.region_id = r.id
-    WHERE l.name = ? COLLATE NOCASE
-    """
-    db_path = resolve_db_path(db)
-    rows, _ = fetch_all(db_path, q, (location,))
-    if not rows:
-        console.print(f"[bold]No region found for location:[/bold] {location.title()} (DB: {db_path})")
-        raise typer.Exit(1)
-    t = make_pipboy_table(f'{location.title()} is located in:')
-    t.add_column("Region");
-    # fetchall returns a list of tuples - even for one col
-    for (region,) in rows:
-        t.add_row(region)
-    console.print(t)
-
-@app.command("places")
-def locations_in(region: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
-    """
-    Look up what locations are in a region of the map (example: `f76 places 'Cranberry Bog'`)
-    """
-    q = """
-    SELECT l.name
-    FROM location l
-    JOIN region r ON l.region_id = r.id
-    WHERE r.name = ? COLLATE NOCASE
-    ORDER BY l.name
-    """
-    db_path = resolve_db_path(db)
-    rows, _ = fetch_all(db_path, q, (region,))
-    if not rows:
-        console.print(f"[bold]No locations found for region:[/bold] {region.title()}")
-        raise typer.Exit(1)
-    t = make_pipboy_table(f'{region.title()} is home to the following locations:')
-    t.add_column("Locations");
-    for (location_name,) in rows:
-        t.add_row(location_name)
-    console.print(t)
-
-@app.command("regions")
-def locations_in(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
-    """
-    List all the regions of the map (example: `f76 regions`)
-    """
-    q = """
-    SELECT r.name
-    FROM region r
-    ORDER BY r.name
-    """
-    db_path = resolve_db_path(db)
-    rows, _ = fetch_all(db_path, q)
-    if not rows:
-        console.print(f"[bold]No regions found.[/bold] Have you ran `f76 init`?")
-        raise typer.Exit(1)
-    t = make_pipboy_table(f'You will find the following Regions in Appalachia:')
-    t.add_column("Regions");
-    for (region_name,) in rows:
-        t.add_row(region_name)
-    console.print(t)
-
-@app.command("where")
+# Junk Command
+@junk_app.command("find")
 def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
     List locations where a junk item can be found (example `f76 where soap`)
@@ -203,6 +107,101 @@ def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
         t.add_row(loc_name, str(qty) if qty is not None else "-", desc)
     console.print(t)
         
+
+# Went with "scrap" because the community recognizes components as "scrap"
+@scrap_app.command("sources")
+def sources(component: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Look up what Junk Items are a source of a given component (example: `f76 sources 'Lead'`)
+    """
+    q = """
+    SELECT i.name, s.quantity
+    FROM component c
+    JOIN item_scraps s ON s.component_id = c.id
+    JOIN item        i ON i.id = s.item_id
+    WHERE c.name = ? COLLATE NOCASE
+    ORDER BY s.quantity DESC, i.name;
+    """
+    db_path = resolve_db_path(db)
+    rows, _ = fetch_all(db_path, q, (component,)) 
+    if not rows:
+        console.print(f"[bold]No items found for component:[/bold] {component} (DB: {db_path})")
+        raise typer.Exit(1)
+    t = make_pipboy_table(f'Items that yield "{component}":')
+    t.add_column("Item"); t.add_column("Qty", justify="right")
+    for item_name, qty in rows:
+        t.add_row(item_name, str(qty))
+    console.print(t)
+
+@location_app.command("find")
+def region_for(location: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Look up what region a location exists in. (example: `f76 whereis 'Wade Airport'`)
+    """
+    q = """
+    SELECT r.name
+    FROM region r
+    JOIN location l ON l.region_id = r.id
+    WHERE l.name = ? COLLATE NOCASE
+    """
+    db_path = resolve_db_path(db)
+    rows, _ = fetch_all(db_path, q, (location,))
+    if not rows:
+        console.print(f"[bold]No region found for location:[/bold] {location.title()} (DB: {db_path})")
+        raise typer.Exit(1)
+    t = make_pipboy_table(f'{location.title()} is located in:')
+    t.add_column("Region");
+    # fetchall returns a list of tuples - even for one col
+    for (region,) in rows:
+        t.add_row(region)
+    console.print(t)
+
+# Conceptually different from the ones above - "find doesn't fit in as well here"
+@region_app.command("locations")
+def locations_in(region: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Look up what locations are in a region of the map (example: `f76 places 'Cranberry Bog'`)
+    """
+    q = """
+    SELECT l.name
+    FROM location l
+    JOIN region r ON l.region_id = r.id
+    WHERE r.name = ? COLLATE NOCASE
+    ORDER BY l.name
+    """
+    db_path = resolve_db_path(db)
+    rows, _ = fetch_all(db_path, q, (region,))
+    if not rows:
+        console.print(f"[bold]No locations found for region:[/bold] {region.title()}")
+        raise typer.Exit(1)
+    t = make_pipboy_table(f'{region.title()} is home to the following locations:')
+    t.add_column("Locations");
+    for (location_name,) in rows:
+        t.add_row(location_name)
+    console.print(t)
+
+@region_app.command("list")
+def locations_in(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    List all the regions of the map (example: `f76 regions`)
+    """
+    q = """
+    SELECT r.name
+    FROM region r
+    ORDER BY r.name
+    """
+    db_path = resolve_db_path(db)
+    rows, _ = fetch_all(db_path, q)
+    if not rows:
+        console.print(f"[bold]No regions found.[/bold] Have you ran `f76 init`?")
+        raise typer.Exit(1)
+    t = make_pipboy_table(f'You will find the following Regions in Appalachia:')
+    t.add_column("Regions");
+    for (region_name,) in rows:
+        t.add_row(region_name)
+    console.print(t)
+
+
 # TODO: 
 # @app.command("enemy")
 

--- a/f76/cli_utils/cli_presentation.py
+++ b/f76/cli_utils/cli_presentation.py
@@ -1,0 +1,20 @@
+from rich.table import Table
+
+PRIMARY_GREEN = "#03e903"
+SECONDARY_GREEN = "#089E08"
+
+def make_pipboy_table(title: str, width: int = 60) -> Table:
+    """
+    Creates table styled like a Fallout Pip-Boy.
+    Keeps consistent headers, colors, and spacing across commands.
+    """
+    return Table(
+        title=f"[{PRIMARY_GREEN}]{title}[/{PRIMARY_GREEN}]",
+        expand=False,
+        width=width,
+        show_lines=True,
+        padding=(0, 1),
+        header_style=f"bold {PRIMARY_GREEN}",
+        border_style=PRIMARY_GREEN,
+        row_styles=[PRIMARY_GREEN, SECONDARY_GREEN] # alternating row background
+    )


### PR DESCRIPTION
## Summary 

Refactors the CLI interface to introduce a noun-first command structure, like `f76 junk scrap <junk item>`

## Context

I was noticing that commands were collecting but not clearly relating to one another, making it hard to remember what command is used with what entity, and was becoming increasingly inconsistent. This work aims to group commands according to the type of entity they act on, so they can be reasoned about as a set of domains with like verbs under each. 

Each "noun" (e.g. junk, scrap, location) is a self-contained [Typer sub-command](https://typer.tiangolo.com/tutorial/subcommands/nested-subcommands/#a-cli-app-for-towns)

I tried to take inspiration from [Human Centered Interaction](https://medium.com/@sachinrekhi/don-normans-principles-of-interaction-design-51025a2c0f33)/Human Computer Interaction principles, [Core API Accessibility Mappings](https://www.w3.org/TR/core-aam-1.2/), and general [CLI Guidelines](https://clig.dev/). 

The most important goal was to ensure the accessibility of this tool, reducing cognitive overload in needing to memorize disparate commands and the entities they acted on. 

## Resulting Hierarchy


Noun | Verb | Example | Reads As
-- | -- | -- | --
junk | find | f76 junk find Soap | Find where Soap spawns
junk | scrap | f76 junk scrap Soap | Show what components Soap yields
scrap | sources | f76 scrap sources Aluminum | Show which junk yields Aluminum
location | find | f76 location find Wade Airport | Find what region Wade Airport is in
region | list | f76 region list | List all regions
region | locations | f76 region locations Toxic Valley | Show all locations within Toxic Valley

- Every noun has a logical verb(s) that match its role
- Commands read like english phrases
- Extensible for upcoming entities, like enemies, chems, etc. 
- Each noun's verbs stand a better change of being guessed or discovered 

## Testing 

1. Junk:
- `f76 junk` -> `scrap` & `find`: `f76 junk scrap 'alarm clock'` / `f76 junk find 'alarm clock'`
<img width="1038" height="598" alt="image" src="https://github.com/user-attachments/assets/a743cab3-6983-40dd-b8cf-00aea412056b" />
<img width="980" height="252" alt="image" src="https://github.com/user-attachments/assets/510237a9-2c0f-46d6-b017-c49a1fd34115" />


2. Scrap: 
- `f76 scrap` -> `sources`: `f76 scrap sources lead` 
<img width="1015" height="592" alt="image" src="https://github.com/user-attachments/assets/cec8cf68-990c-4b9a-91e2-2cc2c8f6c152" />

3. Location:
- `f76 location` -> `find`: `f76 location find 'wade airport'`
<img width="1070" height="169" alt="image" src="https://github.com/user-attachments/assets/579ba552-53b0-48c2-bea9-e0d82039f6f3" />

4. Region:
- `f76 region` -> `list` & `locations`: `f76 region list` / `f76 region locations 'toxic valley'`
<img width="850" height="403" alt="image" src="https://github.com/user-attachments/assets/b14e626c-f24c-45cd-b615-4dc6abca6996" />
<img width="1148" height="608" alt="image" src="https://github.com/user-attachments/assets/37286f0b-1bff-49f4-aa40-0587bfcc40e3" />
