### PR TITLE
Feat: Adds Creature enemy families & groups

### DIFF
--- a/f76/scripts/db_utils.py
+++ b/f76/scripts/db_utils.py
@@ -59,8 +59,9 @@ def upsert_component(cur, name: str) -> int:
 def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]], family: str | None = None):
     """
     Insert or ignore list of enemy groups for given category.
+    Optionally accepts enemy family.
     """
-    # Lookup category ID
+    # Find Category ID
     row = cur.execute(
         "SELECT id FROM enemy_category WHERE name = ?",
         (category,),
@@ -70,7 +71,7 @@ def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]]
     category_id = row[0]
 
     family_id = None
-    # if family given:
+    # Find family ID, if family passed
     if family:
         family_row = cur.execute(
             "SELECT id FROM enemy_family WHERE name = ?",

--- a/f76/scripts/db_utils.py
+++ b/f76/scripts/db_utils.py
@@ -56,7 +56,7 @@ def upsert_component(cur, name: str) -> int:
     cur.execute("INSERT INTO component(name) VALUES (?)", (name,))
     return cur.lastrowid
 
-def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]]):
+def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]], family: str | None = None):
     """
     Insert or ignore list of enemy groups for given category.
     """
@@ -69,16 +69,27 @@ def upsert_enemy_groups(cur, category: str, groups: list[tuple[str, str | None]]
         raise RuntimeError(f"Category {category} could not be found in DB.")
     category_id = row[0]
 
+    family_id = None
+    # if family given:
+    if family:
+        family_row = cur.execute(
+            "SELECT id FROM enemy_family WHERE name = ?",
+            (family,),
+        ).fetchone()
+        if not family_row:
+            raise RuntimeError(f"Family '{family}' could not be found in DB.")
+        family_id = family_row[0]
+        
     for name, url in groups:
         cur.execute(
             """
-            INSERT INTO enemy_group (category_id, name, url)
-            VALUES(?,?,?)
+            INSERT INTO enemy_group (category_id, family_id, name, url)
+            VALUES(?,?,?,?)
             ON CONFLICT(category_id, name) DO NOTHING
             """,
-            (category_id, name, url)
+            (category_id, family_id, name, url)
         )
-    print(f"Loaded {len(groups)} enemy groups for {category}")
+    print(f"Loaded {len(groups)} enemy groups for {category}" + (f" → family {family}" if family else ""))
 
 def set_item_scrap(cur, item_id: int, component_id: int, qty: int):
     """

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -10,6 +10,24 @@ URL = "https://fallout.fandom.com/wiki/Fallout_76_creatures"
 # We know there are 3 categories, so we'll just hardcode them
 ENEMY_CATEGORIES = ["Humans", "Creatures", "Robots"]
 
+# We need to parse the creatures differently
+# starting with parsing the families?
+# This might be another time where it pays off to be more explicit
+# than trying to be clever
+ENEMY_FAMILIES = [
+    "Animals",
+    "Bugs and insects",
+    "Cryptids",
+    "Mirelurks",
+    "Ghouls",
+    "Lost",
+    "Mole miners",
+    "Scorched",
+    "Super mutants",
+    "Other" # For some reason this is Deathclaws, Floaters, and other significant enemies - need to be captured
+]
+    
+# This should work for the Creatures stuff too, we'll just want to pass each family name to this:
 def parse_enemy_groups(soup: BeautifulSoup, category: str) -> list[tuple[str, str | None]]:
     """
     Given a category, finds the next available table under that heading.
@@ -17,11 +35,14 @@ def parse_enemy_groups(soup: BeautifulSoup, category: str) -> list[tuple[str, st
 
     Excludes "Other"
     """
-    anchor = soup.select_one(f"span.mw-headline#{category}")
+    # Ids for multi words become: Bugs_and_insects
+    anchor_id = category.replace(" ", "_")
+    anchor = soup.select_one(f"span.mw-headline#{anchor_id}")
     if not anchor:
         raise RuntimeError(f"Couldn't find {category} anchor")
     
-    h2 = anchor.find_parent("h2")
+    # find_parent accepts a dictionary of filter on attr values
+    h2 = anchor.find_parent(["h2", "h3"])
     table = h2.find_next("table", class_="va-table")
     if not table:
         raise RuntimeError(f"Couldn't {category} find table")
@@ -49,17 +70,22 @@ def parse_enemy_groups(soup: BeautifulSoup, category: str) -> list[tuple[str, st
 def main(db_path: str | pathlib.Path | None = None):
     soup: BeautifulSoup = fetch_soup(URL)
 
-    #print("Soup 🍲: ", soup)    
-    # Make sure enemy categories present in HTML
+    # Validate categories and families exist as headings on the page
     for category in ENEMY_CATEGORIES:
         anchor = soup.select_one(f"span.mw-headline#{category}")
         if not anchor:
-            raise SystemExit(f"Couldn't find {category} anchor")
+            raise SystemExit(f"Couldn't find {category} enemy category anchor")
+    for family in ENEMY_FAMILIES:
+        anchor = soup.select_one(f"span.mw-headline#{category}")
+        if not anchor:
+            raise SystemExit(f"Couldn't find {category} enemy family anchor")
 
-    # We can go ahead and load these into the database
+    # Insert enemy categories
     with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
         with conn:
             cur = conn.cursor()
+
+
             for category in ENEMY_CATEGORIES:
                 cur.execute(
                     """
@@ -69,22 +95,41 @@ def main(db_path: str | pathlib.Path | None = None):
                     """,
                     (category,),
                 )
-    print(f"Loaded {len(ENEMY_CATEGORIES)} enemy categories.")
-    
-    human_groups = parse_enemy_groups(soup, "Humans")
-    robot_groups = parse_enemy_groups(soup, "Robots")
-    
-    with db_conn(db_path, ensure_schema_fn=ensure_schema) as conn:
-        with conn:
-            cur = conn.cursor()
+            print(f"Loaded {len(ENEMY_CATEGORIES)} enemy categories.")
+
+            # Insert enemy families - only for Creatures at this time
+            # Get the category id for Creatures - the only one with families
+            category_row = cur.execute(
+                "SELECT id FROM enemy_category WHERE name = ?",
+                ("Creatures",)
+            ).fetchone()
+
+            if not category_row:
+                raise RuntimeError("Missing 'Creatures' category in the DB!")
+            
+            category_id = category_row[0]
+
+            for family in ENEMY_FAMILIES:
+                cur.execute(
+                    """
+                    INSERT INTO enemy_family (category_id, name)
+                    VALUES (?, ?)
+                    ON CONFLICT(category_id, name) DO NOTHING
+                    """,
+                    (category_id, family)
+                )
+            print(f"Loaded {len(ENEMY_FAMILIES)} enemy families for Creatures category")
+
+            # Parse and insert enemy groups for Humans and Robots
+            human_groups = parse_enemy_groups(soup, "Humans") 
+            robot_groups = parse_enemy_groups(soup, "Robots")
             upsert_enemy_groups(cur, "Humans", human_groups) 
             upsert_enemy_groups(cur, "Robots", robot_groups)
-
-    # TODO: Creatures 
-    # Sometimes, in the case of Creatures, we find various subheadings:
-    # <span class="mw-headline" id="Animals">Animals</span> - these are h3's
-    # There is animals, Bugs and insects, cryptids, etc. 
-    # It's the only one structured like this
+            #Parse and insert the enemy groups for each Creature family
+            for family in ENEMY_FAMILIES:
+                groups = parse_enemy_groups(soup, family)
+                # this needs to be updated to optionally accept a family_id
+                upsert_enemy_groups(cur, "Creatures", groups, family)
 
 if __name__ == "__main__":
     main()

--- a/f76/scripts/scrape/enemies.py
+++ b/f76/scripts/scrape/enemies.py
@@ -7,13 +7,11 @@ from ..db_utils import ensure_schema, upsert_enemy_groups
 
 URL = "https://fallout.fandom.com/wiki/Fallout_76_creatures"
 
-# We know there are 3 categories, so we'll just hardcode them
+# ---- Hardcoded Enemy Categories & Families ----
+# Manually recorded for simplicity 
+# TODO: Consider fetching dynamically 
 ENEMY_CATEGORIES = ["Humans", "Creatures", "Robots"]
 
-# We need to parse the creatures differently
-# starting with parsing the families?
-# This might be another time where it pays off to be more explicit
-# than trying to be clever
 ENEMY_FAMILIES = [
     "Animals",
     "Bugs and insects",
@@ -27,10 +25,9 @@ ENEMY_FAMILIES = [
     "Other" # For some reason this is Deathclaws, Floaters, and other significant enemies - need to be captured
 ]
     
-# This should work for the Creatures stuff too, we'll just want to pass each family name to this:
 def parse_enemy_groups(soup: BeautifulSoup, category: str) -> list[tuple[str, str | None]]:
     """
-    Given a category, finds the next available table under that heading.
+    Given a category or family, finds the next available table under that heading.
     Returns a list of (group_name, url).
 
     Excludes "Other"
@@ -125,10 +122,9 @@ def main(db_path: str | pathlib.Path | None = None):
             robot_groups = parse_enemy_groups(soup, "Robots")
             upsert_enemy_groups(cur, "Humans", human_groups) 
             upsert_enemy_groups(cur, "Robots", robot_groups)
-            #Parse and insert the enemy groups for each Creature family
+            # Parse and insert the enemy groups for each Creature family
             for family in ENEMY_FAMILIES:
                 groups = parse_enemy_groups(soup, family)
-                # this needs to be updated to optionally accept a family_id
                 upsert_enemy_groups(cur, "Creatures", groups, family)
 
 if __name__ == "__main__":

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -54,6 +54,17 @@ CREATE TABLE IF NOT EXISTS enemy_category (
 CREATE TABLE IF NOT EXISTS enemy_group (
   id INTEGER PRIMARY KEY,
   category_id INTEGER NOT NULL REFERENCES enemy_category(id),
+  family_id INTEGER REFERENCES enemy_family(id),
+  name TEXT NOT NULL,
+  url TEXT,
+  UNIQUE(category_id, name)
+);
+
+-- Creatures present us with the issue of an additional hierarchal group
+-- that the other enemy categories don't have, and not *all* the creatures have either
+CREATE TABLE IF NOT EXISTS enemy_family (
+  id INTEGER PRIMARY KEY,
+  category_id INTEGER NOT NULL REFERENCES enemy_category(id),
   name TEXT NOT NULL,
   url TEXT,
   UNIQUE(category_id, name)


### PR DESCRIPTION
## Changes 

- Updates `upsert_enemy_groups`
  - Accepts optional `family` argument
  - Looks up the category_id and the family_id, if family is provided
- Updates `enemies` scrapper script
  - Updates `parse_enemy_groups` - allows for look for h2/h3 headings, since the Creatures enemy_family headings follow the same format, but are a level down
  - Reduces number of DB connections opened/closed 
  - Accounts for capturing Human and Robot enemies and their groups, and the Creates, their enemy_family and their enemy groups
- Updates sql.schema 
  - Adds `enemy_family` table to represent sub-categories under the Creatures category
  - Adds `family_id` foreign key on `enemy_group` to link creature groups to their families 

## Context 

The page we're parsing from Nukapedia - https://fallout.fandom.com/wiki/Fallout_76_creatures - presents us with some inconsistent markup that varies by category:

- Humans and Robots are straightforward:

```
Category -> Group -> Enemy types
```

- Creatures add a third layer of hierarchy:

```
Category -> Family (ex. "Ghouls") -> Group -> Enemy Types
```

<img width="1994" height="1146" alt="image" src="https://github.com/user-attachments/assets/bf5a7f18-60d3-4269-8735-0649066c7bd9" />

You can see in the `enemies.py` script that we've already made the choice to be explicit here, and provide hardcoded values for the enemy categories. The same pattern has been used to record the enemy families. This could be improved so we don't have to manually update these if they change, but avoiding overly-complex logic is a higher priority right now. 


## Testing

Important: These changes included new tables and added columns to existing DB tables, because of this you'll need to nuke your local DB:

```
rm ~/.local/share/f76/fallout.sqlite      
```

1. `f76 init`
2. Should show load of enemy types, including creatures:
<img width="885" height="583" alt="image" src="https://github.com/user-attachments/assets/1311454d-d0e6-4c30-8319-77025b217d74" />

