### PR TITLE
Feat: Adds enemy sub-app and list command

### DIFF
--- a/f76/cli.py
+++ b/f76/cli.py
@@ -52,7 +52,7 @@ def resolve_db_path(db_opt: str | None = None) -> pathlib.Path:
 @junk_app.command("scrap")
 def scrap(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    Look up what components a Junk Item will scrap into (example: `f76 scrap 'Giddyup Buttercup'`)
+    Look up what components a Junk Item will scrap into (example: `f76 junk scrap 'soap'`)
     """
     q = """
     SELECT c.name, s.quantity
@@ -76,7 +76,7 @@ def scrap(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
 @junk_app.command("find")
 def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    List locations where a junk item can be found (example `f76 where soap`)
+    List locations where a junk item can be found (example `f76 junk find 'soap'`)
     """
     db_path = resolve_db_path(db)
     # lazy pop: scrape if we have no rows
@@ -112,7 +112,7 @@ def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
 @scrap_app.command("sources")
 def sources(component: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    Look up what Junk Items are a source of a given component (example: `f76 sources 'Lead'`)
+    Look up what Junk Items are a source of a given component (example: `f76 scrap sources 'lead'`)
     """
     q = """
     SELECT i.name, s.quantity
@@ -137,7 +137,8 @@ def sources(component: str, db: str | None = typer.Option(None, help="Path to fa
 @enemy_app.command("list")
 def list_enemies(category: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    Look up what enemy groups are in each category 
+    Look up what enemy groups are in each category (example: `f76 enemy list 'humans'`)
+    Hint: Categories are currently: Humans, Robots, and Creatures.
     """
     db_path = resolve_db_path(db)
 
@@ -189,7 +190,7 @@ def list_enemies(category: str, db: str | None = typer.Option(None, help="Path t
 @location_app.command("find")
 def region_for(location: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    Look up what region a location exists in. (example: `f76 whereis 'Wade Airport'`)
+    Look up what region a location exists in. (example: `f76 location find 'Wade Airport'`)
     """
     q = """
     SELECT r.name
@@ -214,7 +215,7 @@ def region_for(location: str,db: str | None = typer.Option(None, help="Path to f
 @region_app.command("locations")
 def locations_in(region: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    Look up what locations are in a region of the map (example: `f76 places 'Cranberry Bog'`)
+    Look up what locations are in a region of the map (example: `f76 region locations 'Cranberry Bog'`)
     """
     q = """
     SELECT l.name
@@ -237,7 +238,7 @@ def locations_in(region: str,db: str | None = typer.Option(None, help="Path to f
 @region_app.command("list")
 def locations_in(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
-    List all the regions of the map (example: `f76 regions`)
+    List all the regions of the map (example: `f76 region list`)
     """
     q = """
     SELECT r.name
@@ -254,10 +255,6 @@ def locations_in(db: str | None = typer.Option(None, help="Path to fallout.sqlit
     for (region_name,) in rows:
         t.add_row(region_name)
     console.print(t)
-
-
-# TODO: 
-# @app.command("enemy")
 
 @app.command("init")
 def init(db: str | None = typer.Option(None, help="Path to fallout.sqlite")):

--- a/f76/cli.py
+++ b/f76/cli.py
@@ -11,15 +11,17 @@ from rich import box
 
 app = typer.Typer(help="Fallout 76 Personal Data Assistant")
 # Create sub app for registering our different items that can be acted on
+enemy_app = typer.Typer(help="Explore & analyze enemies")
 junk_app = typer.Typer(help="Explore & analyze junk items")
-scrap_app = typer.Typer(help="Explore & analyze scrap/components")
 location_app = typer.Typer(help="Explore & analyze locations")
 region_app = typer.Typer(help="Explore and analyze regions of Appalachia")
+scrap_app = typer.Typer(help="Explore & analyze scrap/components")
 
+app.add_typer(enemy_app, name="enemy")
 app.add_typer(junk_app, name="junk")
-app.add_typer(scrap_app, name="scrap")
 app.add_typer(location_app, name="location")
 app.add_typer(region_app, name="region")
+app.add_typer(scrap_app, name="scrap")
 
 console = Console()
 
@@ -46,7 +48,7 @@ def resolve_db_path(db_opt: str | None = None) -> pathlib.Path:
     # user data dir fallback
     return default_data_dir() / "fallout.sqlite"
 
-# Register this action under the new junk_app
+# ---- Junk Commands ⏰ ----
 @junk_app.command("scrap")
 def scrap(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
@@ -71,7 +73,6 @@ def scrap(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
         t.add_row(comp, str(qty))
     console.print(t)
 
-# Junk Command
 @junk_app.command("find")
 def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
@@ -107,8 +108,7 @@ def where(item: str, db: str | None = typer.Option(None, help="Path to fallout.s
         t.add_row(loc_name, str(qty) if qty is not None else "-", desc)
     console.print(t)
         
-
-# Went with "scrap" because the community recognizes components as "scrap"
+# ---- Scrap Commands 🛠️ ----
 @scrap_app.command("sources")
 def sources(component: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
@@ -133,6 +133,59 @@ def sources(component: str, db: str | None = typer.Option(None, help="Path to fa
         t.add_row(item_name, str(qty))
     console.print(t)
 
+# ---- Enemy Commands 🙈 ----
+@enemy_app.command("list")
+def list_enemies(category: str, db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
+    """
+    Look up what enemy groups are in each category 
+    """
+    db_path = resolve_db_path(db)
+
+    # handle differently for Creatures - expanded print out
+    if category.lower() == "creatures":
+        q = """
+        SELECT f.name AS family_name, g.name AS group_name
+        FROM enemy_category c
+        JOIN enemy_family f ON f.category_id = c.id
+        LEFT JOIN enemy_group g ON g.family_id = f.id
+        WHERE c.name = ? COLLATE NOCASE
+        ORDER BY f.name, g.name
+        """
+        rows, _ = fetch_all(db_path, q, (category,))
+
+        if not rows:
+            console.print(f"[bold]No creature families or groups found (DB: {db_path})")
+            raise typer.Exit(1)
+
+        t = make_pipboy_table(f"Creature enemy groups by family:")
+        t.add_column("Family")
+        t.add_column("Group")
+
+        for family_name, group_name in rows:
+            t.add_row(family_name or "-", group_name or "-")
+
+        console.print(t)
+        return
+
+    # Default handing for Humans/Robots
+    q ="""
+    SELECT g.name
+    FROM enemy_category c
+    JOIN enemy_group g ON g.category_id = c.id
+    WHERE c.name = ? COLLATE NOCASE
+    ORDER BY g.name
+    """
+    rows, _ = fetch_all(db_path, q, (category,)) 
+    if not rows:
+        console.print(f"[bold]No enemies found for category:[/bold] {category} (DB: {db_path})")
+        raise typer.Exit(1)
+    t = make_pipboy_table(f"Enemies in {category} category:")
+    t.add_column(f"Enemies ({category})");
+    for (enemy_name,) in rows:
+        t.add_row(enemy_name)
+    console.print(t)
+
+# ---- Location Commands 📍 ----
 @location_app.command("find")
 def region_for(location: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):
     """
@@ -156,6 +209,7 @@ def region_for(location: str,db: str | None = typer.Option(None, help="Path to f
         t.add_row(region)
     console.print(t)
 
+# ---- Region Commands 🗺️ ---- 
 # Conceptually different from the ones above - "find doesn't fit in as well here"
 @region_app.command("locations")
 def locations_in(region: str,db: str | None = typer.Option(None, help="Path to fallout.sqlite")):


### PR DESCRIPTION
## Changes

Uses the new enemy tables we recently added (category, family, and group) to return the lists of what enemies fall into what category. 

Creatures are grouped by "family". It didn't make sense for an entirely different command to have to handle finding out the actual groups that make up creatures, or to nest another layer for this entity type. This keeps it flat. That said, it will likely change in the future when I think of a better way to organize this all (because dailies like "Kill 25 insects" are definitely a thing too)

Useful for dailies like "Kill 50 Creatures"/"Cripple 15 robot limbs"/"Use a flamer on 50 humans" when you're wondering "What the hell counts as a [human/creature/robot] again?"

<img width="919" height="731" alt="image" src="https://github.com/user-attachments/assets/7e8b90b3-9afc-47a4-a4de-c6be5a35583b" />

<img width="942" height="690" alt="image" src="https://github.com/user-attachments/assets/a117aef5-622d-4397-92f8-0cfb93e65d04" />

<img width="955" height="804" alt="image" src="https://github.com/user-attachments/assets/42122d1e-b296-4727-8699-3ad41d456b53" />
